### PR TITLE
--added the option to filter routes by config value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,33 @@ Route::group(['laroute' => false], function () {
 
 ```
 
+Another way to filter your routes is to set the ```filter``` option in config file so only the routes with specific key will be added to the laroute. Same key can be applied to group to add every route in it.
+###### app/config/packages/lord/laroute/config.php
+```php
+<?php
+return [
+    'filter' => 'jsroutes'
+];
+```
 
+###### app/routes.php
+```php
+Route::get('/i-will-be-added', [
+    'jsroutes' => true,
+    'as'      => 'route',
+    'uses'    => 'Controller@me'
+]);
+Route::get('/i-wont-be-added', [
+    'as'      => 'route',
+    'uses'    => 'Controller@me'
+]);
+Route::get('/i-wont-be-added-too', [
+    'jsroutes' => true,
+    'laroute' => false,
+    'as'      => 'route',
+    'uses'    => 'Controller@me'
+]);
+```
 ## Licence
 
 [View the licence in this repo.](https://github.com/aaronlord/laroute/blob/master/LICENSE)

--- a/src/Lord/Laroute/Routes/Collection.php
+++ b/src/Lord/Laroute/Routes/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Lord\Laroute\Routes;
 
+use Config;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Lord\Laroute\Routes\Exceptions\ZeroRoutesException;
@@ -60,7 +61,11 @@ class Collection extends \Illuminate\Support\Collection
         $action  = $route->getActionName();
         $laroute = array_get($route->getAction(), 'laroute', true);
 
-        if ($laroute === false) {
+	    $filter = Config::get('laroute::config.filter');
+
+	    $routeHasFilter = array_get($route->getAction(), $filter, false);
+
+        if (($filter and !$routeHasFilter) or $laroute === false) {
             return null;
         }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -18,6 +18,13 @@ return array(
      */
     'namespace' => 'laroute',
 
+	/**
+	 * This allows to specify a filter for generated routes, if one is specified and you
+	 * add the filter to the route or group of routes only this routes will be added to file,
+	 * still, if route has laroute => false it will not be added
+	 */
+	'filter' => null,
+
     /**
      * The path to the template `laroute.js` file. This is the file that contains
      * the ported helper Laravel url/route functions and the route data to go


### PR DESCRIPTION
This is my propose to add an ability to filter routes by specific key. For now by default all routes are added and then some of them are excluded by `laroute => false` key. While in many cases it is fine there are situations like mine when I use some routes that are coming from some package and I have no chance to exclude them from routing in the current way. So I came with the idea of filter option in config which allows us to set the key to filter all routes by. So if we set it to 'jsroutes' we will only get the routes that have this key set to true, but we still can set laroute to false and exlude some of them.
