### PR TITLE
Test PHP 7.0 and use travis-ci container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,14 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
+
+matrix:
+    allow_failures:
+        - php: 7.0
+
+sudo: false
 
 before_script:
   - composer self-update


### PR DESCRIPTION
This is a follow-up to #9.

I've searched for aaronlord/laroute on travis-ci and I have found no project. Let me know if you need any help setting up travis-ci.

**Change summary:**
Add PHP 7.0 to the tested php versions in .travis.yml.
Add sudo: false to .travis.yml to use the container-based infrastructure of travis-ci.