### PR TITLE
Rename fire() method in command to handle() for Laravel 5.5 support

### DIFF
--- a/src/Console/Commands/LarouteGeneratorCommand.php
+++ b/src/Console/Commands/LarouteGeneratorCommand.php
@@ -68,7 +68,7 @@ class LarouteGeneratorCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         try {
             $filePath = $this->generator->compile(


### PR DESCRIPTION
Renamed deprecated fire() method to handle(). Support for fire() has been removed in Laravel 5.5