### PR TITLE
Add the option to disable the action in the laroute call

### DIFF
--- a/config/laroute.php
+++ b/config/laroute.php
@@ -43,12 +43,18 @@ return [
     'action_namespace' => '',
 
     /*
+     * If we use the actions, this will expose the PHP classes and methods
+     * See: https://github.com/aaronlord/laroute/issues/58
+     */
+    'use_actions' => true,
+
+    /*
      * The path to the template `laroute.js` file. This is the file that contains
      * the ported helper Laravel url/route functions and the route data to go
      * with them.
      */
     'template' => 'vendor/lord/laroute/src/templates/laroute.js',
-    
+
     /*
      * Appends a prefix to URLs. By default the prefix is an empty string.
     *

--- a/src/LarouteServiceProvider.php
+++ b/src/LarouteServiceProvider.php
@@ -83,7 +83,7 @@ class LarouteServiceProvider extends ServiceProvider
             'command.laroute.generate',
             function ($app) {
                 $config     = $app['config'];
-                $routes     = new Routes($app['router']->getRoutes(), $config->get('laroute.filter', 'all'), $config->get('laroute.action_namespace', ''));
+                $routes     = new Routes($app['router']->getRoutes(), $config->get('laroute.filter', 'all'), $config->get('laroute.action_namespace', ''), $config->get('laroute.use_actions', true));
                 $generator  = $app->make('Lord\Laroute\Generators\GeneratorInterface');
 
                 return new LarouteGeneratorCommand($config, $routes, $generator);

--- a/src/Routes/Collection.php
+++ b/src/Routes/Collection.php
@@ -8,9 +8,9 @@ use Lord\Laroute\Routes\Exceptions\ZeroRoutesException;
 
 class Collection extends \Illuminate\Support\Collection
 {
-    public function __construct(RouteCollection $routes, $filter, $namespace)
+    public function __construct(RouteCollection $routes, $filter, $namespace, $useActions = true)
     {
-        $this->items = $this->parseRoutes($routes, $filter, $namespace);
+        $this->items = $this->parseRoutes($routes, $filter, $namespace, $useActions);
     }
 
     /**
@@ -23,14 +23,14 @@ class Collection extends \Illuminate\Support\Collection
      * @return array
      * @throws ZeroRoutesException
      */
-    protected function parseRoutes(RouteCollection $routes, $filter, $namespace)
+    protected function parseRoutes(RouteCollection $routes, $filter, $namespace, $useActions)
     {
         $this->guardAgainstZeroRoutes($routes);
 
         $results = [];
 
         foreach ($routes as $route) {
-            $results[] = $this->getRouteInformation($route, $filter, $namespace);
+            $results[] = $this->getRouteInformation($route, $filter, $namespace, $useActions);
         }
 
         return array_values(array_filter($results));
@@ -59,20 +59,23 @@ class Collection extends \Illuminate\Support\Collection
      *
      * @return array
      */
-    protected function getRouteInformation(Route $route, $filter, $namespace)
+    protected function getRouteInformation(Route $route, $filter, $namespace, $useActions)
     {
         $host    = $route->domain();
         $methods = $route->methods();
         $uri     = $route->uri();
         $name    = $route->getName();
-        $action  = $route->getActionName();
+        $action = '';
         $laroute = array_get($route->getAction(), 'laroute', null);
 
-        if(!empty($namespace)) {
-            $a = $route->getAction();
+        if ($useActions) {
+            $action  = $route->getActionName();
+            if(!empty($namespace)) {
+                $a = $route->getAction();
 
-            if(isset($a['controller'])) {
-                $action = str_replace($namespace.'\\', '', $action);
+                if(isset($a['controller'])) {
+                    $action = str_replace($namespace.'\\', '', $action);
+                }
             }
         }
 


### PR DESCRIPTION
Add the option to disable the action in the laroute call to prevent exposing the PHP class and method names

This will close https://github.com/aaronlord/laroute/issues/58