### PR TITLE
Add 'exclude' feature

### DIFF
--- a/config/laroute.php
+++ b/config/laroute.php
@@ -51,13 +51,16 @@ return [
     
     /*
      * Appends a prefix to URLs. By default the prefix is an empty string.
-    *
-    */
+     *
+     */
     'prefix' => '',
 
     /*
-     * what to exclude from the output file
-     * ex. ['action', 'methods', 'host']
+     * Array of strings which indicate which, if any, route properties should be excluded from the compiled file.
+     * Intended to reduce the bundled file size by excluding rote properties not being referenced in production.
+     *
+     * The array may left empty or may include one or any of the following:
+     * ['host', 'methods', 'uri', 'action', 'name']
      */
     'exclude' => [],
 

--- a/config/laroute.php
+++ b/config/laroute.php
@@ -55,4 +55,10 @@ return [
     */
     'prefix' => '',
 
+    /*
+     * what to exclude from the output file
+     * ex. ['action', 'methods', 'host']
+     */
+    'exclude' => [],
+
 ];

--- a/src/Routes/Collection.php
+++ b/src/Routes/Collection.php
@@ -85,7 +85,9 @@ class Collection extends \Illuminate\Support\Collection
                 break;
         }
 
-        return compact('host', 'methods', 'uri', 'name', 'action');
+        $items = ['host', 'methods', 'uri', 'action', 'name'];
+
+        return compact(array_diff($items, config('laroute.exclude')));
     }
 
 }

--- a/src/Routes/Collection.php
+++ b/src/Routes/Collection.php
@@ -8,6 +8,8 @@ use Lord\Laroute\Routes\Exceptions\ZeroRoutesException;
 
 class Collection extends \Illuminate\Support\Collection
 {
+    protected static $routeProperties = ['host', 'methods', 'uri', 'action', 'name'];
+
     public function __construct(RouteCollection $routes, $filter, $namespace)
     {
         $this->items = $this->parseRoutes($routes, $filter, $namespace);
@@ -85,9 +87,7 @@ class Collection extends \Illuminate\Support\Collection
                 break;
         }
 
-        $items = ['host', 'methods', 'uri', 'action', 'name'];
-
-        return compact(array_diff($items, config('laroute.exclude')));
+        return compact(array_diff(static::$routeProperties, config('laroute.exclude')));
     }
 
 }


### PR DESCRIPTION
This adds an option to 'exclude' properties from the generated route package, by type.

Adds a new config option 'except', which accepts an array of properties to be excluded from the compiled bundle. This approach maintains non-breaking support with current implementations.

This is inspired by a previous PR (https://github.com/aaronlord/laroute/pull/59) which was allowed to expire without adoption but is very useful. This reduces the bundle size by a lot if used properly. I urge that this should be considered. Thanks.