### PR TITLE
Laroute Macro added on Route

### DIFF
--- a/src/LarouteServiceProvider.php
+++ b/src/LarouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Lord\Laroute;
 
+use Illuminate\Routing\Route;
 use Illuminate\Support\ServiceProvider;
 use Lord\Laroute\Console\Commands\LarouteGeneratorCommand;
 use Lord\Laroute\Routes\Collection as Routes;
@@ -17,6 +18,12 @@ class LarouteServiceProvider extends ServiceProvider
     {
         $source = $this->getConfigPath();
         $this->publishes([$source => config_path('laroute.php')], 'config');
+
+        Route::macro('laroute', function() {
+            $this->setAction(array_merge($this->getAction(), ['laroute' => true]));
+
+            return $this;
+        });
     }
 
     /**


### PR DESCRIPTION
What do you think about register a `macro` to make the flow similar to the new standard of Laravel?

https://laravel.com/docs/5.6/routing#named-routes

e.g:

```php
// old way
Route::get('show/{user}', [
    'laroute' => true,
    'as' => 'show.user',
    'uses' => 'UserController@show'
]);

// new way
Route::get('show/{user}', 'UserController@show')->name('show.user')->laroute();
```